### PR TITLE
Add new feature: delete review reaction

### DIFF
--- a/internal/app/professor/repository/review.go
+++ b/internal/app/professor/repository/review.go
@@ -84,7 +84,9 @@ func (p *professorRepositoryImplPostgre) DeleteProfessorReview(ctx context.Conte
 				goqu.I("reviews.prof_id").Eq(params.ProfId), 
 				goqu.I("reviews.user_id").Eq(params.UserId),
 			),
-		)
+		). 
+		SetDialect(goqu.GetDialect("postgres")).
+		Prepared(true)
 
 	query, args, err := qb.ToSQL()
 	if err != nil {

--- a/internal/app/reaction/contracts/repository.go
+++ b/internal/app/reaction/contracts/repository.go
@@ -12,4 +12,5 @@ type ReviewReactionRepositoryProvider interface {
 
 type ReviewReactionRepository interface {
 	CreateReaction(ctx context.Context, entity *entity.ReviewReaction) error
+	DeleteReaction(ctx context.Context, entity *entity.ReviewReaction) error
 }

--- a/internal/app/reaction/contracts/service.go
+++ b/internal/app/reaction/contracts/service.go
@@ -10,4 +10,5 @@ import (
 type ReviewReactionService interface {
 	PublishReaction(ctx context.Context, queueType rabbitmq.QueueType, req *dto.ReviewReactionRequest) error
 	CreateReaction(ctx context.Context, req *dto.ReviewReactionRequest) error
+	DeleteReaction(ctx context.Context, req *dto.ReviewReactionRequest) error
 }

--- a/internal/app/reaction/service/struct.go
+++ b/internal/app/reaction/service/struct.go
@@ -6,14 +6,14 @@ import (
 	"go.uber.org/zap"
 )
 
-type ReviewReactionService struct {
+type reviewReactionService struct {
 	reactionRepo contracts.ReviewReactionRepositoryProvider
 	logger *zap.Logger
 	rabbitMQ *rabbitmq.RabbitMQ 
 }
 
 func NewReviewReactionService(reactionRepo contracts.ReviewReactionRepositoryProvider, logger *zap.Logger, rabbitMQ *rabbitmq.RabbitMQ) contracts.ReviewReactionService {
-	return &ReviewReactionService{
+	return &reviewReactionService{
 		reactionRepo: reactionRepo,
 		logger: logger,
 		rabbitMQ:     rabbitMQ,

--- a/internal/app/review/controller/struct.go
+++ b/internal/app/review/controller/struct.go
@@ -29,5 +29,5 @@ func (c *ReviewController) Mount(r *echo.Group) {
 	profR := r.Group("/reviews")
 
 	profR.POST("/:id/reactions", c.CreateReaction, c.mdlwr.Authenticate())
-
+	profR.DELETE("/:id/reactions", c.DeleteReaction, c.mdlwr.Authenticate())
 }

--- a/internal/infra/server/http.go
+++ b/internal/infra/server/http.go
@@ -141,6 +141,10 @@ func (h *httpServer) MountWorkers() {
 			QueueType: rabbitmq.ReactionReviewCreateQueue,
 			HandleFn: h.Services.reactionSvc.CreateReaction,
 		},
+		{
+			QueueType: rabbitmq.ReactionReviewDeleteQueue,
+			HandleFn: h.Services.reactionSvc.DeleteReaction,
+		},
 	}
 
 	h.RabbitMQ.StartReactionWorkers(context.Background(), workers)
@@ -159,7 +163,7 @@ func (h *httpServer) GracefullyShutdown() {
 func (h *httpServer) shutdown() {
 	h.Logger.Info("Shutting down application...")
 
-	timeoutFunc := time.AfterFunc(5*time.Second, func() {
+	timeoutFunc := time.AfterFunc(10*time.Second, func() {
 		log.Println("Timeout, forcefully shutting down...")
 	})
 

--- a/internal/infra/server/server.go
+++ b/internal/infra/server/server.go
@@ -1,7 +1,15 @@
 package server
 
 type Server interface {
+	// Start starts the server and listens for incoming requests
 	Start()	
+
+	// GracefullyShutdown gracefully shuts down the server on interrupt
 	GracefullyShutdown()
+
+	// MountHandlers mounts all the HTTP handlers and routes
 	MountHandlers()
+
+	// MountWorkers mounts all the workers or background jobs
+	MountWorkers()
 }


### PR DESCRIPTION
This pull request includes several changes to add delete functionality for review reactions and improve the overall code structure. The most important changes include adding a delete reaction method across various layers, updating the HTTP server configuration, and enhancing documentation.

### Adding delete reaction functionality:

* [`internal/app/reaction/contracts/repository.go`](diffhunk://#diff-d3d914fc9b48a236736aead3002db288de0c5796c421bcf8ba1d1a82702392dcR15): Added `DeleteReaction` method to `ReviewReactionRepository` interface.
* [`internal/app/reaction/contracts/service.go`](diffhunk://#diff-f80ad46d970eb9936c6037c4d2e65ffc948be7f94e5ebc24b83e03f997183ce6R13): Added `DeleteReaction` method to `ReviewReactionService` interface.
* [`internal/app/reaction/repository/review-reaction.go`](diffhunk://#diff-a12a02a8cedd6a719a4a17708d7cf1e2f04d8640f442ee8c241b843e396c3bf2R44-R82): Implemented `DeleteReaction` method in `reviewReactionRepositoryImplPostgre` to handle deletion logic.
* [`internal/app/reaction/service/review-reaction.go`](diffhunk://#diff-e09137717a46be3f17db6dc0d98bcfa32e748a8a1a72f0fcaa5ed1ebfcd16862R51-R76): Implemented `DeleteReaction` method in `reviewReactionService` to handle service layer logic.
* [`internal/app/review/controller/reaction.go`](diffhunk://#diff-5255f1e0eb09f52c295c2662db60099b5cfc712ec52ea2ceb809eb400b1d4c44R51-R88): Added `DeleteReaction` method to `ReviewController` to handle HTTP requests for deleting reactions.

### HTTP server updates:

* [`internal/app/review/controller/struct.go`](diffhunk://#diff-d086b5d35e5f521b19651d3cd67b94c8639b9d269200e303da7856567120c1bdL32-R32): Added route for deleting reactions.
* [`internal/infra/server/http.go`](diffhunk://#diff-57a2d68cb47c807697b2115452d016939630c0beb4aefe5ac4b1dad747c68fe9R144-R147): Added worker for handling delete reaction messages in the RabbitMQ queue.

### Code structure improvements:

* [`internal/infra/server/server.go`](diffhunk://#diff-a45113344b9420ecaca15d4680d46bb6364f2861432ba9ef8d7279b76a7372f4R4-R14): Enhanced documentation for the `Server` interface methods.
* [`internal/infra/server/http.go`](diffhunk://#diff-57a2d68cb47c807697b2115452d016939630c0beb4aefe5ac4b1dad747c68fe9L162-R166): Increased shutdown timeout to 10 seconds for a more graceful shutdown process.

### Minor refactoring:

* [`internal/app/reaction/service/struct.go`](diffhunk://#diff-1f0504070c685b2b8aae0432f7516240535420955d39aee5b7776c59125e1d97L9-R16): Changed `ReviewReactionService` to `reviewReactionService` to follow naming conventions.
* [`internal/app/reaction/service/review-reaction.go`](diffhunk://#diff-e09137717a46be3f17db6dc0d98bcfa32e748a8a1a72f0fcaa5ed1ebfcd16862L14-R14): Updated method receivers to use the new naming convention. [[1]](diffhunk://#diff-e09137717a46be3f17db6dc0d98bcfa32e748a8a1a72f0fcaa5ed1ebfcd16862L14-R14) [[2]](diffhunk://#diff-e09137717a46be3f17db6dc0d98bcfa32e748a8a1a72f0fcaa5ed1ebfcd16862L25-R25)