### PR TITLE
Add new response data: like and dislike review counter

### DIFF
--- a/internal/app/review/repository/struct.go
+++ b/internal/app/review/repository/struct.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	reviewTableName    = "reviews"
+	reactionTableName  = "review_reactions"
 	professorTableName = "professors"
 	userTableName      = "users"
 )

--- a/internal/dto/review.go
+++ b/internal/dto/review.go
@@ -8,6 +8,8 @@ type FetchReviewResponse struct {
 	DiffRate     float32                `json:"difficultyRating"`
 	FriendlyRate float32                `json:"friendlyRating"`
 	CreatedAt    string                 `json:"createdAt"`
+	Like         int                    `json:"like"`
+	Dislike      int                    `json:"dislike"`
 	User         FetchUserResponse      `json:"user"`
 	Professor    FetchProfessorResponse `json:"professor"`
 }

--- a/internal/entity/review.go
+++ b/internal/entity/review.go
@@ -14,6 +14,8 @@ type Review struct {
 
 type ReviewWithRelations struct {
 	Review
-	User      User      `db:"user"`
-	Professor Professor `db:"professor"`
+	User        User      `db:"user"`
+	Professor   Professor `db:"professor"`
+	LikeCounter int       `db:"like_counter"`
+	DislikeCounter int       `db:"dislike_counter"`
 }

--- a/pkg/util/formatter/review.go
+++ b/pkg/util/formatter/review.go
@@ -32,6 +32,8 @@ func FormatReviewEntityToDto(review *entity.ReviewWithRelations) dto.FetchReview
 		Comment:      review.Comment,
 		DiffRate:     review.DiffRate,
 		FriendlyRate: review.FriendlyRate,
+		Like:         review.LikeCounter,
+		Dislike:      review.DislikeCounter,
 		Professor:    FormatProfessorEntityToDto(review.Professor),
 		User:         FormatUserEntityToDto(&review.User),
 	}


### PR DESCRIPTION
This pull request introduces changes to the review repository and related structures to include reaction counts (likes and dislikes) for reviews. The most important changes include updating the SQL queries, modifying the data structures to store reaction counts, and adjusting the formatting functions to include these counts in the responses.

Changes to SQL queries:

* [`internal/app/review/repository/review.go`](diffhunk://#diff-a51732f9f1ed6fea05ef018dc63b685b67244fa4cf9e40a34d07f96629578a38R29-R40): Added `like_counter` and `dislike_counter` fields to the SQL query and grouped results by review, user, and professor IDs. Also joined the `review_reactions` table to fetch reaction counts. [[1]](diffhunk://#diff-a51732f9f1ed6fea05ef018dc63b685b67244fa4cf9e40a34d07f96629578a38R29-R40) [[2]](diffhunk://#diff-a51732f9f1ed6fea05ef018dc63b685b67244fa4cf9e40a34d07f96629578a38R49-R52) [[3]](diffhunk://#diff-a51732f9f1ed6fea05ef018dc63b685b67244fa4cf9e40a34d07f96629578a38R98-R99)

Updates to data structures:

* [`internal/entity/review.go`](diffhunk://#diff-2e4be6766e4eeb6082183427199938706c25cde35a9682a621cb743fb472b15cR19-R20): Added `LikeCounter` and `DislikeCounter` fields to the `ReviewWithRelations` struct.
* [`internal/dto/review.go`](diffhunk://#diff-9025a412d5f95b6a379d280146a9b663ea7102be98bd91af3153f0b0fd91ddf8R11-R12): Added `Like` and `Dislike` fields to the `FetchReviewResponse` struct.
* [`internal/app/review/repository/struct.go`](diffhunk://#diff-179e36a8401d5c9d6a7a392112c7d9180995ff5a4a95c0c940317e168b927f7aR10): Added `reactionTableName` constant for the `review_reactions` table.

Adjustments to formatting functions:

* [`pkg/util/formatter/review.go`](diffhunk://#diff-afc3bf5cbe299d96f3a3dbef89b1bc2c333f1640151f2faf1f8e53dbc7e972a5R35-R36): Updated the `FormatReviewEntityToDto` function to include `LikeCounter` and `DislikeCounter` in the formatted review DTO.